### PR TITLE
Fix link from profile page to details page

### DIFF
--- a/src/components/Characters/Characters.jsx
+++ b/src/components/Characters/Characters.jsx
@@ -12,7 +12,7 @@ const Characters = (props) => {
                {allCharacters.map(character =>
                   <>
                      <div key={character.characterName} className={styles.icon}>
-                        <Link to={`/characterDetails`} state={character.characterName.toLowerCase()}>
+                        <Link to={`/character-details/${character.characterName}`} state={character.characterName.toLowerCase()}>
                            <img className={styles.characterIcon} key={character.characterName} src={`https://api.genshin.dev/characters/${character.characterName.toLowerCase()}/icon`} alt="icon" />
                            <p>{character.characterName[0].toUpperCase() + character.characterName.slice(1,20)}</p>
                            {/* add a handler for the longer names and ones with a "-" in it */}

--- a/src/components/Weapons/Weapons.jsx
+++ b/src/components/Weapons/Weapons.jsx
@@ -12,7 +12,7 @@ const Weapons = (props) => {
                {allWeapons.map(weapon =>
                   <>
                      <div key={weapon.weaponName} className={styles.icon}>
-                        <Link to={`/weaponDetails`} state={weapon.weaponName.toLowerCase()}>
+                        <Link to={`/weapon-details/${weapon.weaponName}`} state={weapon.weaponName.toLowerCase()}>
                            <img className={styles.weaponIcon} key={weapon.weaponName} src={`https://api.genshin.dev/weapons/${weapon.weaponName.toLowerCase()}/icon`} alt="icon" />
                            <p>{weapon.weaponName[0].toUpperCase() + weapon.weaponName.slice(1,20)}</p>
                            {/* add weapon name handler here */}

--- a/src/pages/CharacterIndex/CharacterIndex.jsx
+++ b/src/pages/CharacterIndex/CharacterIndex.jsx
@@ -10,7 +10,7 @@ const CharacterIndex = (props) => {
             <div key={character} className={styles.icon}>
               <Link to={`/character-details/${character}`} state={character}>
                 <img className={styles.characterIcon} src={`https://api.genshin.dev/characters/${character}/icon`} alt="icon" />
-                <div className={styles.box}>{character[0].toUpperCase() + character.slice(1,20)}</div>
+                <div className={styles.box}>{character[0].toUpperCase() + character.slice(1, 20)}</div>
               </Link>
             </div>
           )}


### PR DESCRIPTION
Clicking on weapons/characters from profile page now correctly redirect to their details page.